### PR TITLE
Removed layout attribute from page tag

### DIFF
--- a/PayUM/Pumbolt/view/frontend/layout/checkout_index_index.xml
+++ b/PayUM/Pumbolt/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.root">
             <arguments>

--- a/PayUM/Pumbolt/view/frontend/layout/checkout_index_index.xml
+++ b/PayUM/Pumbolt/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.root">
             <arguments>


### PR DESCRIPTION
Due to layout="1column" specified on your checkout_index_index layout handle, Header & footer are rendering on checkout page. The preferred checkout page layout is layout="checkout" and it's already applied in core Magento's checkout layout file.
So no need to mention this attribute here.